### PR TITLE
Fix Statcast functions failing when min param is None

### DIFF
--- a/mlb_stats_mcp/tools/statcast_tools.py
+++ b/mlb_stats_mcp/tools/statcast_tools.py
@@ -345,7 +345,8 @@ async def get_statcast_batter_exitvelo_barrels(
         )
 
         # Call pybaseball's statcast_batter_exitvelo_barrels function
-        df = statcast_batter_exitvelo_barrels(year, minBBE)
+        # pybaseball expects "q" (qualified) as the default, not None
+        df = statcast_batter_exitvelo_barrels(year, minBBE if minBBE is not None else "q")
 
         if len(df) == 0:
             raise Exception("No statcast data found")
@@ -401,7 +402,7 @@ async def get_statcast_pitcher_exitvelo_barrels(
         )
 
         # Call pybaseball's statcast_pitcher_exitvelo_barrels function
-        df = statcast_pitcher_exitvelo_barrels(year, minBBE)
+        df = statcast_pitcher_exitvelo_barrels(year, minBBE if minBBE is not None else "q")
 
         if len(df) == 0:
             raise Exception("No statcast data found")
@@ -459,7 +460,7 @@ async def get_statcast_batter_expected_stats(
         )
 
         # Call pybaseball's statcast_batter_expected_stats function
-        df = statcast_batter_expected_stats(year, minPA)
+        df = statcast_batter_expected_stats(year, minPA if minPA is not None else "q")
 
         if len(df) == 0:
             raise Exception("No statcast data found")
@@ -515,7 +516,7 @@ async def get_statcast_pitcher_expected_stats(
         )
 
         # Call pybaseball's statcast_pitcher_expected_stats function
-        df = statcast_pitcher_expected_stats(year, minPA)
+        df = statcast_pitcher_expected_stats(year, minPA if minPA is not None else "q")
 
         if len(df) == 0:
             raise Exception("No statcast data found")


### PR DESCRIPTION
## Problem

The four Statcast leaderboard functions fail with a `ParserError` when called with default parameters:

```
pandas.errors.ParserError: Error tokenizing data. C error: Expected 1 fields in line 38, saw 4
```

**Root cause**: `get_statcast_batter_exitvelo_barrels`, `get_statcast_pitcher_exitvelo_barrels`, `get_statcast_batter_expected_stats`, and `get_statcast_pitcher_expected_stats` all declare `minBBE`/`minPA` as `Optional[int] = None`. When `None` is passed to pybaseball, it gets interpolated as the literal string `"None"` in the Baseball Savant URL:

```
https://baseballsavant.mlb.com/leaderboard/statcast?type=batter&year=2025&min=None&csv=true
```

Savant doesn't recognize `min=None` and returns the **HTML page** instead of CSV data, causing the pandas CSV parser to fail.

pybaseball's own functions default to `"q"` (qualified), which produces the correct URL:

```
https://baseballsavant.mlb.com/leaderboard/statcast?type=batter&year=2025&min=q&csv=true
```

## Fix

Pass `"q"` to pybaseball when the parameter is `None`, matching pybaseball's own defaults. This is a 4-line change across the 4 affected functions.

## Testing

Before fix:
```python
>>> asyncio.run(get_statcast_batter_exitvelo_barrels(year=2025))
# ParserError: Expected 1 fields in line 38, saw 4
```

After fix:
```python
>>> asyncio.run(get_statcast_batter_exitvelo_barrels(year=2025))
# {'data': [...], 'count': 251, 'total_rows': 251, 'columns': [...]}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)